### PR TITLE
fix: CI pipeline failures - detekt, ktlint, and compiler errors

### DIFF
--- a/cli/src/nativeMain/kotlin/io/github/klaw/cli/chat/ChatTui.kt
+++ b/cli/src/nativeMain/kotlin/io/github/klaw/cli/chat/ChatTui.kt
@@ -160,7 +160,7 @@ internal class ChatTui(
                     "${AnsiColors.GREEN}$agentName:${AnsiColors.RESET}"
                 }
             val labelVisible = if (msg.role == "user") "You:" else "$agentName:"
-            val prefixVisible = " ${labelVisible} "
+            val prefixVisible = " $labelVisible "
             val contentWidth = innerWidth - prefixVisible.length
             val prefix = " $label "
             val contentLines = wrapText(msg.content, contentWidth)
@@ -181,7 +181,10 @@ internal class ChatTui(
         return lines
     }
 
-    private fun wrapText(text: String, width: Int): List<String> {
+    private fun wrapText(
+        text: String,
+        width: Int,
+    ): List<String> {
         if (width <= 0) return listOf(text)
         val result = mutableListOf<String>()
         for (paragraph in text.split('\n')) {
@@ -202,8 +205,10 @@ internal class ChatTui(
     }
 
     /** Position cursor at (row, col=1) and write line content, clearing the rest of the row. */
-    private fun StringBuilder.posLine(row: Int, content: String): StringBuilder =
-        append("\u001B[${row};1H\u001B[2K$content")
+    private fun StringBuilder.posLine(
+        row: Int,
+        content: String,
+    ): StringBuilder = append("\u001B[$row;1H\u001B[2K$content")
 
     /** Write directly to stdout fd, bypassing Kotlin buffered print. */
     private fun rawWrite(s: String) {

--- a/cli/src/nativeMain/kotlin/io/github/klaw/cli/command/ChatCommand.kt
+++ b/cli/src/nativeMain/kotlin/io/github/klaw/cli/command/ChatCommand.kt
@@ -70,12 +70,17 @@ internal class ChatCommand(
                     } catch (e: Exception) {
                         val msg =
                             when (e::class.simpleName) {
-                                "ConnectException", "IOException" ->
+                                "ConnectException", "IOException" -> {
                                     "Cannot connect to gateway at $wsUrl — is the gateway running?"
-                                "WebSocketException" ->
+                                }
+
+                                "WebSocketException" -> {
                                     "WebSocket connection failed — gateway may not have console chat enabled"
-                                else ->
+                                }
+
+                                else -> {
                                     "Connection error: ${e::class.simpleName}"
+                                }
                             }
                         events.trySend(ChatEvent.MessageReceived(msg))
                     }
@@ -95,7 +100,7 @@ internal class ChatCommand(
                                 escState = 0 // consume direction byte (A/B/C/D), ignore
                             }
 
-                            else ->
+                            else -> {
                                 when (byte) {
                                     0x1B -> escState = 1
 
@@ -115,6 +120,7 @@ internal class ChatCommand(
 
                                     else -> if (byte >= 32) events.send(ChatEvent.KeyPressed(byte.toChar()))
                                 }
+                            }
                         }
                     }
                 }

--- a/engine/src/main/kotlin/io/github/klaw/engine/tools/UtilityTools.kt
+++ b/engine/src/main/kotlin/io/github/klaw/engine/tools/UtilityTools.kt
@@ -24,7 +24,9 @@ class UtilityTools(
         text: String,
     ): String =
         try {
-            socketServerProvider.get().pushToGateway(OutboundSocketMessage(channel = channel, chatId = chatId, content = text))
+            socketServerProvider.get().pushToGateway(
+                OutboundSocketMessage(channel = channel, chatId = chatId, content = text),
+            )
             "OK: message sent to $channel/$chatId"
         } catch (e: Exception) {
             "Error: ${e.message}"

--- a/engine/src/test/kotlin/io/github/klaw/engine/memory/AutoRagServiceTest.kt
+++ b/engine/src/test/kotlin/io/github/klaw/engine/memory/AutoRagServiceTest.kt
@@ -101,7 +101,7 @@ class AutoRagServiceTest {
         }
 
     @Test
-    fun `ftsSearch scoped to chatId — excludes other chatIds`() =
+    fun `ftsSearch scoped to chatId - excludes other chatIds`() =
         runBlocking {
             insertMessage(
                 id = "m1",
@@ -124,7 +124,7 @@ class AutoRagServiceTest {
         }
 
     @Test
-    fun `ftsSearch scoped to segmentStart — excludes earlier messages`() =
+    fun `ftsSearch scoped to segmentStart - excludes earlier messages`() =
         runBlocking {
             insertMessage(
                 id = "m1",

--- a/engine/src/test/kotlin/io/github/klaw/engine/message/MessageRepositoryTest.kt
+++ b/engine/src/test/kotlin/io/github/klaw/engine/message/MessageRepositoryTest.kt
@@ -24,7 +24,7 @@ class MessageRepositoryTest {
     }
 
     @Test
-    fun `save returns Unit — backward compatible`() =
+    fun `save returns Unit - backward compatible`() =
         runBlocking {
             repo.save("id1", "telegram", "chat1", "user", "text", "hello")
             val count = database.messagesQueries.countMessages().executeAsOne()


### PR DESCRIPTION
- Fix detekt MaxLineLength violation in UtilityTools.kt by wrapping long line
- Fix ktlint violations in ChatTui.kt: redundant curly braces in string
  templates, function signatures needing multiline params
- Fix ktlint violations in ChatCommand.kt: when-entry bracing and blank
  lines between multiline when-conditions
- Replace em-dash (—) with hyphen (-) in test method names to fix
  InvalidPathException during Kotlin test compilation on some filesystems

https://claude.ai/code/session_018kKaZgeLvvR5SwMK5ae9WT